### PR TITLE
removed error print when it is not needed

### DIFF
--- a/public/src/PostprocessData.cpp
+++ b/public/src/PostprocessData.cpp
@@ -431,7 +431,6 @@ void processSAP34(MovieInfoRec *mir) {
                             if (moof->trafInfo[k].sbgpInfo[l].grouping_type == 'roll' && (tir->hdlrInfo->componentSubType == 'vide' || tir->hdlrInfo->componentSubType == 'soun')) {
                                 UInt32 sgpdIndex = getSgpdIndex(moof->trafInfo[k].sgpdInfo, moof->trafInfo[k].numSgpd, moof->trafInfo[k].sbgpInfo[l].grouping_type);
                                 if (sgpdIndex == moof->trafInfo[k].numSgpd) {
-                                    errprint("grouping_type %s in sbgp is not found for any sgpd in moof number %d\n", ostypetostr(moof->trafInfo[k].sbgpInfo[l].grouping_type), j + 1);
                                     continue;
                                 }
 


### PR DESCRIPTION
Attempt to fix #33 

It seems that the validator prints an error, but this should not constitute erroneous behavior. If there is a better solution to the issue, feel free to make the change.