### PR TITLE
postprocess fragment bug fix

### DIFF
--- a/public/src/PostprocessData.cpp
+++ b/public/src/PostprocessData.cpp
@@ -223,7 +223,7 @@ OSErr postprocessFragmentInfo(MovieInfoRec *mir) {
                 if (mir->moofInfo[i].trafInfo[j].tfdtFound) {
                     long double cumulatedTackFragmentDecodeTime = (long double) mir->tirList[index].cumulatedTackFragmentDecodeTime / (long double) mir->tirList[index].mediaTimeScale;
                     long double baseMediaDecodeTime = (long double) mir->moofInfo[i].trafInfo[j].baseMediaDecodeTime / (long double) mir->tirList[index].mediaTimeScale;
-                    if(abs(cumulatedTackFragmentDecodeTime - baseMediaDecodeTime) > 0.001) {
+                    if(fabsl(cumulatedTackFragmentDecodeTime - baseMediaDecodeTime) > 0.001) {
                     //if (mir->moofInfo[i].trafInfo[j].baseMediaDecodeTime != mir->tirList[index].cumulatedTackFragmentDecodeTime) {
                         if (i == 0 && vg.dashSegment) {
                             warnprint("Warning: tfdt base media decode time %Lf not equal to accumulated decode time %Lf for track %d for the first fragment of the movie. \n", (long double) mir->moofInfo[i].trafInfo[j].baseMediaDecodeTime / (long double) mir->tirList[index].mediaTimeScale, (long double) mir->tirList[index].cumulatedTackFragmentDecodeTime / (long double) mir->tirList[index].mediaTimeScale, mir->moofInfo[i].trafInfo[j].track_ID);


### PR DESCRIPTION
The code checks the difference between 2 long doubles using abs.
However, abs works on integers, so that also has the side effect of rounding the diff. 
In my test stream, the difference is 0.02, and following the rounding on the call to abs, it becomes 0.
The if block is not entered, and baseMediaDecodeTime is effectively ignored, leading to false errors later 
(e.g. mismatch between sidx earliest_presentation_time and first frame pts)
The fix is to move to fabsl.